### PR TITLE
FLASK_PIKA_POOL_PARAMS is now optional.

### DIFF
--- a/flask_pika.py
+++ b/flask_pika.py
@@ -33,7 +33,7 @@ class Pika(object):
             Initialize the Flask Pika extension
         """
         pika_params = app.config['FLASK_PIKA_PARAMS']
-        pool_params = app.config['FLASK_PIKA_POOL_PARAMS']
+        pool_params = app.config.get('FLASK_PIKA_POOL_PARAMS', None)
 
         self.debug = app.debug
         self.logger = app.logger


### PR DESCRIPTION
Will now assigne `None` to `pool_params` if `FLASK_PIKA_POOL_PARAMS` doesn't exist in the app config.